### PR TITLE
Allow usage in React 18

### DIFF
--- a/src/Jazzicon.tsx
+++ b/src/Jazzicon.tsx
@@ -36,7 +36,7 @@ export class Jazzicon extends React.Component<IJazziconProps, IJazziconState> {
 
   public state: IJazziconState = Jazzicon.propsToState(this.props);
 
-  public componentWillReceiveProps(props: IJazziconProps) {
+  public UNSAFE_componentWillReceiveProps(props: IJazziconProps) {
     this.setState(
       Jazzicon.propsToState(props),
     );


### PR DESCRIPTION
In React 18 `componentWillReceiveProps` won't work, and in React 17 it produces the warning:

```
Warning: componentWillReceiveProps has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.

* Move data fetching code or side effects to componentDidUpdate.
* If you're updating state whenever props change, refactor your code to use memoization techniques or move it to static getDerivedStateFromProps. Learn more at: https://reactjs.org/link/derived-state
* Rename componentWillReceiveProps to UNSAFE_componentWillReceiveProps to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.

Please update the following components: %s, Jazzicon
```

This change simply renames `componentWillReceiveProps` -> `UNSAFE_componentWillReceiveProps`, allowing it to function in React 18 and removing the warning for React 17.